### PR TITLE
GitHub Actions で lint / test を自動実行する CI を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: リポジトリをチェックアウト
+        uses: actions/checkout@v4
+
+      - name: Node.js をセットアップ
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: 依存関係をインストール
+        run: npm ci
+
+      - name: Lint を実行
+        run: npm run lint
+
+      - name: テストを実行
+        run: npm run test


### PR DESCRIPTION
## 概要

main / develop ブランチに対して、lint / test を自動実行する GitHub Actions の CI を追加しました。

## 変更内容

- `.github/workflows/ci.yml` を追加
  - `push` と `pull_request`（branches: main, develop）をトリガーに設定
  - `ubuntu-latest` 上で Node.js 20 をセットアップ
  - `npm ci` で依存関係をインストール
  - `npm run lint` を実行
  - `npm run test` を実行

## 動作確認

- この Pull Request の作成時に GitHub Actions が起動し、
  - lint が成功すること
  - test が成功すること
  を確認しました。

関連 Issue: #4 
Closes #4 
