### PR TITLE
ランディングページとルーティングの最小実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "react-router-dom": "^7.10.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -2411,6 +2412,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3665,6 +3679,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.10.1.tgz",
+      "integrity": "sha512-gHL89dRa3kwlUYtRQ+m8NmxGI6CgqN+k4XyGjwcFoQwwCWF6xXpOCUlDovkXClS0d0XJN/5q7kc5W3kiFEd0Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.10.1.tgz",
+      "integrity": "sha512-JNBANI6ChGVjA5bwsUIwJk7LHKmqB4JYnYfzFwyp2t12Izva11elds2jx7Yfoup2zssedntwU0oZ5DEmk5Sdaw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.10.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -3776,6 +3828,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "react-router-dom": "^7.10.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,15 @@
+import { HashRouter, Routes, Route } from 'react-router-dom'
+import LandingPage from './features/quiz/pages/LandingPage/LandingPage'
+import NotFoundPage from './app/pages/NotFoundPage/NotFoundPage'
+
 function App() {
   return (
-    <main className="centered">
-      <div className="stack-md">
-        <h1>LogiQuest 10</h1>
-        <p>10問で論理的思考力を鍛えるトレーニングアプリです。</p>
-        <p>この画面には、今後トップページのコンテンツを実装していきます。</p>
-      </div>
-    </main>
+    <HashRouter>
+      <Routes>
+        <Route path="/" element={<LandingPage />} />
+        <Route path="*" element={<NotFoundPage />} />
+      </Routes>
+    </HashRouter>
   )
 }
 

--- a/src/app/pages/NotFoundPage/NotFoundPage.tsx
+++ b/src/app/pages/NotFoundPage/NotFoundPage.tsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom'
+
+function NotFoundPage() {
+  return (
+    <main className="centered">
+      <div className="stack-md">
+        <h1>ページが見つかりません</h1>
+        <p>お探しのページは存在しないか、移動または削除された可能性があります。</p>
+        <p>
+          <Link to="/">トップへ戻る</Link>
+        </p>
+      </div>
+    </main>
+  )
+}
+
+export default NotFoundPage

--- a/src/features/quiz/pages/LandingPage/LandingPage.tsx
+++ b/src/features/quiz/pages/LandingPage/LandingPage.tsx
@@ -1,0 +1,13 @@
+function LandingPage() {
+  return (
+    <main className="centered">
+      <div className="stack-md">
+        <h1>LogiQuest 10</h1>
+        <p>10問で鍛える、思考の瞬発力。</p>
+        <p>短時間でのトレーニングを通じて、あなたの論理的思考力を向上させます。</p>
+      </div>
+    </main>
+  )
+}
+
+export default LandingPage


### PR DESCRIPTION
## 概要

LogiQuest 10 のランディングページと、今後の画面遷移の土台となるルーティングを最小構成で実装しました。

## 変更内容

- `react-router-dom` を導入し、`HashRouter` ベースのルーティングを構成
- ランディングページ `LandingPage` を追加
  - タイトルとアプリの概要テキストを表示
- 404 用の `NotFoundPage` を追加
  - 存在しないURLアクセス時にメッセージと「トップへ戻る」リンクを表示
- `App.tsx` をルーティングエントリとして修正
  - `/` → `LandingPage`
  - `*` → `NotFoundPage`

## 動作確認

- `npm run dev`
  - `http://localhost:5173/#/` にアクセスし、ランディングページが表示されることを確認
  - `http://localhost:5173/#/unknown` にアクセスし、NotFoundPage が表示されることを確認
- `npm run lint`
  - エラーなく完了することを確認
- `npm run test`
  - 既存の App のテストが成功することを確認
- `npm run build`
  - エラーなく完了することを確認

関連 Issue: #5 
Closes #5 
