### PR TITLE
GitHub Pages 用の設定とデプロイワークフローを追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: リポジトリをチェックアウト
+        uses: actions/checkout@v4
+
+      - name: Node.js をセットアップ
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: 依存関係をインストール
+        run: npm ci
+
+      - name: 本番ビルドを実行
+        run: npm run build
+
+      - name: ビルド成果物をアップロード
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: GitHub Pages にデプロイ
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>logiquest-10</title>
   </head>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/logiquest-10/',
   plugins: [react()],
   test: {
     // React コンポーネントを jsdom 上でテストするための共通設定


### PR DESCRIPTION
## 概要

LogiQuest 10 を GitHub Pages で公開するための設定を追加しました。

## 変更内容

- Vite の `base` を GitHub Pages 用パスに設定
  - `vite.config.ts` に `base: '/logiquest-10/'` を追加
- GitHub Pages 用のデプロイワークフローを追加
  - `.github/workflows/deploy.yml` を新規作成
  - `main` ブランチへの push と `workflow_dispatch` をトリガーに `npm ci` / `npm run build` / GitHub Pages へのデプロイを実行
- favicon の設定を削除
  - `index.html` の `href="/vite.svg"` を削除し、存在しないパスへの参照を解消

## 動作確認

- `npm run build`
  - ローカルでエラーなくビルドが完了することを確認
- `npm run lint`
  - Lint がエラーなく完了することを確認
- `npm run test`
  - テストがエラーなく完了することを確認

## 補足

- GitHub Pages の Source は「GitHub Actions」を使用する前提です。
  - `main` ブランチにマージ後、Actions タブおよび Pages 設定画面でデプロイ結果を確認します。

Closes #6
