### PR TITLE
ルーティング構成と共通レイアウト（Header/Footer）の追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,7 @@
-import { HashRouter, Routes, Route } from 'react-router-dom'
-import LandingPage from './features/quiz/pages/LandingPage/LandingPage'
-import NotFoundPage from './app/pages/NotFoundPage/NotFoundPage'
+import Router from './app/router/Router'
 
 function App() {
-  return (
-    <HashRouter>
-      <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="*" element={<NotFoundPage />} />
-      </Routes>
-    </HashRouter>
-  )
+  return <Router />
 }
 
 export default App

--- a/src/app/layout/RootLayout.module.css
+++ b/src/app/layout/RootLayout.module.css
@@ -1,0 +1,20 @@
+.root {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.main {
+  flex: 1;
+  max-width: 960px;
+  width: 100%;
+  margin: 0 auto;
+  padding-block: var(--spacing-lg);
+  padding-inline: var(--spacing-md);
+}
+
+@media (min-width: var(--bp-md)) {
+  .main {
+    padding-inline: var(--spacing-lg);
+  }
+}

--- a/src/app/layout/RootLayout.tsx
+++ b/src/app/layout/RootLayout.tsx
@@ -1,0 +1,18 @@
+import { Outlet } from 'react-router-dom'
+import Header from '../../shared/layout/Header/Header'
+import Footer from '../../shared/layout/Footer/Footer'
+import styles from './RootLayout.module.css'
+
+function RootLayout() {
+  return (
+    <div className={styles.root}>
+      <Header />
+      <div className={styles.main}>
+        <Outlet />
+      </div>
+      <Footer />
+    </div>
+  )
+}
+
+export default RootLayout

--- a/src/app/router/Router.tsx
+++ b/src/app/router/Router.tsx
@@ -1,0 +1,23 @@
+import { HashRouter, Routes, Route } from 'react-router-dom'
+import RootLayout from '../layout/RootLayout'
+import LandingPage from '../../features/quiz/pages/LandingPage/LandingPage'
+import QuizPage from '../../features/quiz/pages/QuizPage/QuizPage'
+import ResultPage from '../../features/quiz/pages/ResultPage/ResultPage'
+import NotFoundPage from '../pages/NotFoundPage/NotFoundPage'
+
+function Router() {
+  return (
+    <HashRouter>
+      <Routes>
+        <Route path="/" element={<RootLayout />}>
+          <Route index element={<LandingPage />} />
+          <Route path="quiz" element={<QuizPage />} />
+          <Route path="result" element={<ResultPage />} />
+          <Route path="*" element={<NotFoundPage />} />
+        </Route>
+      </Routes>
+    </HashRouter>
+  )
+}
+
+export default Router

--- a/src/features/quiz/pages/QuizPage/QuizPage.tsx
+++ b/src/features/quiz/pages/QuizPage/QuizPage.tsx
@@ -1,0 +1,12 @@
+function QuizPage() {
+  return (
+    <main className="centered">
+      <div className="stack-md">
+        <h1>クイズに挑戦</h1>
+        <p>ここにクイズ画面の UI が入ります。</p>
+      </div>
+    </main>
+  )
+}
+
+export default QuizPage

--- a/src/features/quiz/pages/ResultPage/ResultPage.tsx
+++ b/src/features/quiz/pages/ResultPage/ResultPage.tsx
@@ -1,0 +1,12 @@
+function ResultPage() {
+  return (
+    <main className="centered">
+      <div className="stack-md">
+        <h1>結果</h1>
+        <p>ここに結果画面の UI が入ります。</p>
+      </div>
+    </main>
+  )
+}
+
+export default ResultPage

--- a/src/shared/layout/Footer/Footer.module.css
+++ b/src/shared/layout/Footer/Footer.module.css
@@ -1,0 +1,18 @@
+.root {
+  border-top: 1px solid var(--color-border);
+  margin-top: auto;
+  background: #020617;
+}
+
+.inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0.75rem var(--spacing-md);
+  font-size: 0.75rem;
+  text-align: center;
+}
+
+.text {
+  color: var(--color-text);
+  opacity: 0.6;
+}

--- a/src/shared/layout/Footer/Footer.tsx
+++ b/src/shared/layout/Footer/Footer.tsx
@@ -1,0 +1,13 @@
+import styles from './Footer.module.css'
+
+function Footer() {
+  return (
+    <footer className={styles.root}>
+      <div className={styles.inner}>
+        <small className={styles.text}>© 2025 LogiQuest 10</small>
+      </div>
+    </footer>
+  )
+}
+
+export default Footer

--- a/src/shared/layout/Header/Header.module.css
+++ b/src/shared/layout/Header/Header.module.css
@@ -1,0 +1,32 @@
+.root {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  border-bottom: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.9);
+  backdrop-filter: blur(10px);
+}
+
+.inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0.75rem var(--spacing-md);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo {
+  text-decoration: none;
+  color: var(--color-text);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  font-size: 1rem;
+  text-transform: uppercase;
+}
+
+.nav {
+  display: flex;
+  gap: var(--spacing-md);
+  font-size: 0.875rem;
+}

--- a/src/shared/layout/Header/Header.tsx
+++ b/src/shared/layout/Header/Header.tsx
@@ -1,0 +1,19 @@
+import { Link } from 'react-router-dom'
+import styles from './Header.module.css'
+
+function Header() {
+  return (
+    <header className={styles.root}>
+      <div className={styles.inner}>
+        <Link to="/" className={styles.logo}>
+          LogiQuest 10
+        </Link>
+        <nav className={styles.nav}>
+          {/* TODO: テーマ切り替えトグルや前回スコアバッジを配置予定 */}
+        </nav>
+      </div>
+    </header>
+  )
+}
+
+export default Header


### PR DESCRIPTION
## 概要

LogiQuest 10 のルーティング構成と共通レイアウト（Header/Footer）を追加しました。

## 変更内容

- `app/router/Router.tsx` を新規作成し、以下のルートを定義
  - `/`（index）: `LandingPage`
  - `/quiz`: `QuizPage`
  - `/result`: `ResultPage`
  - 上記以外のパス: `NotFoundPage`
- `app/layout/RootLayout.tsx` を新規作成し、共通の `Header` / `Footer` / `Outlet` を配置
- `shared/layout/Header/*` に共通ヘッダーコンポーネントとスタイルを追加
- `shared/layout/Footer/*` に共通フッターコンポーネントとスタイルを追加
- `features/quiz/pages/QuizPage/QuizPage.tsx` にクイズ画面用の仮コンテンツを追加
- `features/quiz/pages/ResultPage/ResultPage.tsx` に結果画面用の仮コンテンツを追加
- `App.tsx` からルート定義を切り出し、`Router` コンポーネント経由で画面を表示する構成に変更

## 動作確認

- `npm run dev`
  - `#/` にアクセスして `LandingPage` が表示されることを確認
  - `#/quiz` にアクセスして `QuizPage` が表示されることを確認
  - `#/result` にアクセスして `ResultPage` が表示されることを確認
  - `#/hogehoge` など未定義パスで `NotFoundPage` が表示されることを確認
- `npm run test`
  - テストがエラーなく完了することを確認

Closes #7
