### PR TITLE
テーマコンテキストとテーマトグル機能の追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,12 @@
 import Router from './app/router/Router'
+import { ThemeProvider } from './shared/theme/ThemeContext'
 
 function App() {
-  return <Router />
+  return (
+    <ThemeProvider>
+      <Router />
+    </ThemeProvider>
+  )
 }
 
 export default App

--- a/src/shared/layout/Header/Header.module.css
+++ b/src/shared/layout/Header/Header.module.css
@@ -3,7 +3,9 @@
   top: 0;
   z-index: 10;
   border-bottom: 1px solid var(--color-border);
-  background: rgba(15, 23, 42, 0.9);
+
+  /* ヘッダーは背景トークンをベースにした半透明オーバーレイにして、スクロール時も下のコンテンツをほんのり見せる */
+  background: var(--color-header-bg);
   backdrop-filter: blur(10px);
 }
 
@@ -25,8 +27,33 @@
   text-transform: uppercase;
 }
 
-.nav {
+/* ヘッダー右側のアクションエリア（テーマトグルや今後のボタンを配置するスペース） */
+.right {
   display: flex;
   gap: var(--spacing-md);
   font-size: 0.875rem;
+}
+
+/* テーマトグルボタン（pill 形状の小さめボタン） */
+.themeToggle {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px; /* 完全な pill 形状にするため十分大きな radius を指定 */
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: var(--transition-interactive);
+}
+
+.themeToggle:hover {
+  background-color: var(--color-card);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.6);
+}
+
+/* キーボード操作時にフォーカス位置がわかるようにするための強調スタイル */
+.themeToggle:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }

--- a/src/shared/layout/Header/Header.tsx
+++ b/src/shared/layout/Header/Header.tsx
@@ -1,16 +1,29 @@
 import { Link } from 'react-router-dom'
+import { useTheme } from '../../theme/ThemeContext'
 import styles from './Header.module.css'
 
 function Header() {
+  const { theme, toggleTheme } = useTheme()
+
+  const isSoft = theme === 'dark-soft'
+  const label = isSoft ? 'テーマ: ネイビー' : 'テーマ: ブラック'
+
   return (
     <header className={styles.root}>
       <div className={styles.inner}>
         <Link to="/" className={styles.logo}>
           LogiQuest 10
         </Link>
-        <nav className={styles.nav}>
-          {/* TODO: テーマ切り替えトグルや前回スコアバッジを配置予定 */}
-        </nav>
+        <div className={styles.right}>
+          <button
+            type="button"
+            className={styles.themeToggle}
+            onClick={toggleTheme}
+            aria-pressed={isSoft}
+          >
+            {label}
+          </button>
+        </div>
       </div>
     </header>
   )

--- a/src/shared/theme/ThemeContext.tsx
+++ b/src/shared/theme/ThemeContext.tsx
@@ -1,0 +1,86 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+  type Dispatch,
+  type SetStateAction,
+} from 'react'
+
+export type Theme = 'dark-strong' | 'dark-soft'
+
+type ThemeContextValue = {
+  theme: Theme
+  setTheme: Dispatch<SetStateAction<Theme>>
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+// localStorage 用のアプリ固有キー（他アプリとの衝突を避ける）
+const STORAGE_KEY = 'logiquest-10:theme'
+
+function loadInitialTheme(): Theme {
+  // SSR やテスト環境など window がないケースでは安全側のデフォルトにフォールバック
+  if (typeof window === 'undefined') {
+    return 'dark-strong'
+  }
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY)
+    if (stored === 'dark-strong' || stored === 'dark-soft') {
+      return stored
+    }
+  } catch {
+    // localStorage へのアクセスが制限されている環境では、保存値は無視してデフォルトに戻す
+  }
+
+  return 'dark-strong'
+}
+
+type ThemeProviderProps = {
+  children: ReactNode
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>(() => loadInitialTheme())
+
+  // 副作用（DOM の data-theme と localStorage への永続化）は theme の変更に紐づけてこの useEffect 1 箇所に集約する
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.setAttribute('data-theme', theme)
+    }
+
+    try {
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(STORAGE_KEY, theme)
+      }
+    } catch {
+      // 永続化に失敗しても UI の動作は継続させる
+    }
+  }, [theme])
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'dark-strong' ? 'dark-soft' : 'dark-strong'))
+  }
+
+  const value: ThemeContextValue = {
+    theme,
+    setTheme,
+    toggleTheme,
+  }
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+// カスタムフックを同一ファイルから export したいので、この行だけルールを無効化
+// eslint-disable-next-line react-refresh/only-export-components
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) {
+    // Provider のラップ漏れにすぐ気付けるよう、開発時は明示的に例外を投げる
+    throw new Error('useTheme must be used within ThemeProvider')
+  }
+  return ctx
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,12 +1,38 @@
 /* デザイントークン */
 :root {
-  /* 色 */
-  --color-bg: #0f172a;
-  --color-card: #111827;
-  --color-accent: #38bdf8;
-  --color-text: #e5e7eb;
-  --color-border: #4b5563;
-  --color-text-muted: #4b5563;
+  /* =========================
+     テーマ別カラーパレット
+     ========================= */
+
+  /* dark-strong: ブラック */
+  --color-bg-strong: #020617;
+  --color-card-strong: #020617;
+  --color-accent-strong: #38bdf8;
+  --color-text-strong: #e5e7eb;
+  --color-border-strong: #4b5563;
+  --color-text-muted-strong: #6b7280;
+
+  /* dark-soft: ネイビー */
+  --color-bg-soft: #0f172a;
+  --color-card-soft: #111827;
+  --color-accent-soft: #38bdf8;
+  --color-text-soft: #e5e7eb;
+  --color-border-soft: #4b5563;
+  --color-text-muted-soft: #9ca3af;
+
+  /* =========================
+     実際に参照するトークン
+     初回レンダリングで data-theme がまだ無いときのデフォルト（ブラック／strong）
+     ========================= */
+  --color-bg: var(--color-bg-strong);
+  --color-card: var(--color-card-strong);
+  --color-accent: var(--color-accent-strong);
+  --color-text: var(--color-text-strong);
+  --color-border: var(--color-border-strong);
+  --color-text-muted: var(--color-text-muted-strong);
+
+  /* ヘッダー用の半透明背景色（テーマに関わらず共通のトーンで使う） */
+  --color-header-bg: rgba(15, 23, 42, 0.9);
 
   /* 余白（8px グリッド） */
   --spacing-sm: 0.5rem;
@@ -29,6 +55,25 @@
     box-shadow 0.15s ease-out;
 }
 
+/* data-theme は ThemeProvider（ThemeContext）が <html> に付与し、その値に応じてトークンを切り替える */
+:root[data-theme='dark-strong'] {
+  --color-bg: var(--color-bg-strong);
+  --color-card: var(--color-card-strong);
+  --color-accent: var(--color-accent-strong);
+  --color-text: var(--color-text-strong);
+  --color-border: var(--color-border-strong);
+  --color-text-muted: var(--color-text-muted-strong);
+}
+
+:root[data-theme='dark-soft'] {
+  --color-bg: var(--color-bg-soft);
+  --color-card: var(--color-card-soft);
+  --color-accent: var(--color-accent-soft);
+  --color-text: var(--color-text-soft);
+  --color-border: var(--color-border-soft);
+  --color-text-muted: var(--color-text-muted-soft);
+}
+
 /* ベーススタイル */
 @layer base {
   *,
@@ -37,6 +82,7 @@
     box-sizing: border-box;
   }
 
+  /* :where(...) を使ってセレクタの詳細度を上げずにベーススタイルを適用する */
   :where(html, body) {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
## 概要

LogiQuest 10 にテーマコンテキストとテーマトグル機能を追加し、
ヘッダーから `dark-strong` / `dark-soft` の切り替えができるようにしました。

## 変更内容

- `shared/theme/ThemeContext.tsx` を新規作成
  - `Theme = 'dark-strong' | 'dark-soft'` を定義
  - `ThemeProvider` でテーマ状態を管理
  - `useEffect` 内で `data-theme` と `localStorage` を更新する形に整理し、
    状態と副作用の責務を分離
  - `useTheme` フックを提供（`theme` / `setTheme` / `toggleTheme`）

- `App.tsx` でアプリ全体を `ThemeProvider` でラップ

- `styles/globals.css` にテーマ別カラーパレットと、
  `data-theme` に応じて切り替わる色トークンを定義

- `shared/layout/Header/Header.tsx` にテーマトグルボタンを追加
  - ヘッダー右側を `nav` ではなくアクションエリア（`div.right`）として扱うように変更
  - `aria-pressed` によりトグルボタンの状態が分かるように対応

- `Header.module.css` にテーマトグルボタン用のスタイルを追加
  - pill 型ボタンと hover / focus-visible 時の見た目を定義

## 動作確認

- `npm run dev`
  - ヘッダー右上の「テーマ: ブラック」ボタンをクリックすると、
    テーマが `dark-strong` → `dark-soft` に切り替わることを確認
  - もう一度クリックすると、`dark-soft` → `dark-strong` に戻ることを確認
  - テーマ切り替え時に、背景色やカード色が変化することを目視で確認
  - テーマを切り替えた状態でページを再読込し、
    最後に選択したテーマが維持されていることを確認

- `npm run test`
  - テストがエラーなく完了することを確認

Closes #8
